### PR TITLE
Fix backup registry value 

### DIFF
--- a/Invoke-D365FFOAxDBRestoreFromBACPAC.ps1
+++ b/Invoke-D365FFOAxDBRestoreFromBACPAC.ps1
@@ -102,6 +102,26 @@ TRUNCATE TABLE BATCHSERVERGROUP
 "@
 Invoke-DbaQuery -SqlInstance localhost -Database AxDB -Query $sqlSysTablesTruncate
 
+#fix retail users
+$fixDBusers = @"
+use AxDB;
+DROP USER IF EXISTS [axdeployextuser];
+DROP USER IF EXISTS [axretaildatasyncuser];
+DROP USER IF EXISTS [axretailruntimeuser];
+DROP USER IF EXISTS [axdbadmin];
+GO
+CREATE USER [axdeployextuser] FROM LOGIN [axdeployextuser];
+CREATE USER [axdbadmin] FROM LOGIN [axdbadmin];
+CREATE USER [axretaildatasyncuser] FROM LOGIN [axretaildatasyncuser];
+CREATE USER [axretailruntimeuser] FROM LOGIN [axretailruntimeuser];
+EXEC sp_addrolemember 'db_owner', 'axdeployextuser';
+EXEC sp_addrolemember 'db_owner', 'axdbadmin';
+EXEC sp_addrolemember 'db_owner', 'axretaildatasyncuser';
+EXEC sp_addrolemember 'db_owner', 'axretailruntimeuser';
+GO
+"@
+Invoke-DbaQuery -SqlInstance localhost -Database AxDB -Query $fixDBusers
+
 ## Clean up Power BI settings
 Write-Host "Cleaning up Power BI settings" -ForegroundColor Yellow
 Invoke-DbaQuery -SqlInstance localhost -Database AxDB -Query "UPDATE PowerBIConfig set CLIENTID = '', APPLICATIONKEY = '', REDIRECTURL = ''"

--- a/Invoke-D365FFOAxDBRestoreFromBAK.ps1
+++ b/Invoke-D365FFOAxDBRestoreFromBAK.ps1
@@ -101,6 +101,26 @@ TRUNCATE TABLE BATCHSERVERGROUP
 "@
 Invoke-DbaQuery -SqlInstance localhost -Database AxDB -Query $sqlSysTablesTruncate
 
+#fix retail users
+$fixDBusers = @"
+use AxDB;
+DROP USER IF EXISTS [axdeployextuser];
+DROP USER IF EXISTS [axretaildatasyncuser];
+DROP USER IF EXISTS [axretailruntimeuser];
+DROP USER IF EXISTS [axdbadmin];
+GO
+CREATE USER [axdeployextuser] FROM LOGIN [axdeployextuser];
+CREATE USER [axdbadmin] FROM LOGIN [axdbadmin];
+CREATE USER [axretaildatasyncuser] FROM LOGIN [axretaildatasyncuser];
+CREATE USER [axretailruntimeuser] FROM LOGIN [axretailruntimeuser];
+EXEC sp_addrolemember 'db_owner', 'axdeployextuser';
+EXEC sp_addrolemember 'db_owner', 'axdbadmin';
+EXEC sp_addrolemember 'db_owner', 'axretaildatasyncuser';
+EXEC sp_addrolemember 'db_owner', 'axretailruntimeuser';
+GO
+"@
+Invoke-DbaQuery -SqlInstance localhost -Database AxDB -Query $fixDBusers
+
 ## INFO: get Admin email address/tenant
 Write-Host "Getting information about tenant and admin account from AxDB" -ForegroundColor Yellow
 Invoke-DbaQuery -SqlInstance localhost -Database AxDB -Query "Select ID, Name, NetworkAlias from UserInfo where ID = 'Admin'" | FT

--- a/Invoke-D365FFOMovingData2OneDiskAndVMOptimization.ps1
+++ b/Invoke-D365FFOMovingData2OneDiskAndVMOptimization.ps1
@@ -273,6 +273,10 @@ Get-Partition -DriveLetter $diskK_ServiceVolume.Replace(':','') | Set-Partition 
 Get-Partition -DriveLetter $diskP_SSDDisk.Replace(':','') | Set-Partition -NewDriveLetter $diskK_ServiceVolume.Replace(':','') -Verbose
 #endregion Renaming disks <--
 
+#region Fix registry value -->
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Dynamics\AX\7.0\SDK" -Name "BackupPath" -Value "$diskK_ServiceVolume\DynamicsBackup"
+#endregion Fix registry value <--
+
 #region Attach SQL Databases -->
 Write-Host 'Start SQL Services back' -ForegroundColor Yellow
 Start-DbaService


### PR DESCRIPTION
The package deployment failed after the Invoke-D365FFOMovingData2OneDiskAndVMOptimization.ps1 script.
![image](https://user-images.githubusercontent.com/10218336/220895834-5faa2f21-2bcb-48e4-aed8-180dd55d555b.png)

The following just fix the registry value to the existing disk.
